### PR TITLE
Fix not hooked calls in hookFunc()

### DIFF
--- a/funcap.py
+++ b/funcap.py
@@ -234,13 +234,12 @@ class FunCapHook(DBG_Hooks):
 
         self.output("hooking function: %s()" % func)
 
-        f = get_func(ea)
-        start_ea = f.startEA
-        end_ea = f.endEA
-        if jump:
-            self.add_call_and_jump_bp(start_ea, end_ea)
-        else:
-            self.add_call_bp(start_ea, end_ea)
+        chunks = Chunks(ea)
+        for (start_ea, end_ea) in chunks:
+            if jump:
+                self.add_call_and_jump_bp(start_ea, end_ea)
+            else:
+                self.add_call_bp(start_ea, end_ea)
         self.hooked.append(func)
 
     def hookSeg(self, seg = "", jump = False):


### PR DESCRIPTION
I've stumbled upon a bug when `hookFunc()` sometimes does not hook all calls in function. This happens only when function is "chunked" across segment.

Before the change, there was a single call to `Heads` with a start and end taken from `get_func()`. Thing is, when function is chunked, `get_func` returns only first chunk and skips all other chunks. So we need to call `Heads` on all function chunks.

I've only fixed it for x86, I guess there may be similar bugs in other parts of code
